### PR TITLE
add idempotence requirement to booking calls

### DIFF
--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -271,7 +271,7 @@ paths:
 
         This creates a new booking reservation.
 
-        This call has to be idempotent. To be able to safely retry a call on any network error or timeout, therefore it MUST not fail on retry or create a duplicate reservation. The idempotency key is the UUID.
+        This call has to be idempotent. To be able to safely retry a call on any network error or timeout, therefore it MUST not fail on retry or create a duplicate reservation. The idempotency key is the UUID. A supplier SHOULD verify that a retried request with the same UUID is matching the original reservation data, to avoid erroneous clients generating repeating UUIDs and response with the status 400 and ErrorCode 1005 in such case.
       operationId: 'createReservation'
       parameters:
         - $ref: '#/components/parameters/SupplierId'

--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -270,6 +270,8 @@ paths:
         **WARNING: this endpoint may live under a different domain, path or both depending on the supplier endpoint URL returned by the GET /suppliers.**
 
         This creates a new booking reservation.
+
+        This call has to be idempotent. To be able to safely retry a call on any network error or timeout, therefore it MUST not fail on retry or create a duplicate reservation. The idempotency key is the UUID.
       operationId: 'createReservation'
       parameters:
         - $ref: '#/components/parameters/SupplierId'
@@ -297,6 +299,8 @@ paths:
         **WARNING: this endpoint may live under a different domain, path or both depending on the supplier endpoint URL returned by the GET /suppliers.**
 
         This expires the availability hold of an existing reservation so that the availablity is release for other booking reservations. This request is a courtesy, however Resellers SHOULD send this in order to ensure proper cleanup of any outstanding holds.
+
+        This call has to be idempotent. To be able to safely retry a call on any network error or timeout, therefore it MUST not fail on retry. The idempotency key is the UUID.
       operationId: 'expireReservation'
       parameters:
         - $ref: '#/components/parameters/SupplierId'
@@ -353,6 +357,8 @@ paths:
         **WARNING: this endpoint may live under a different domain, path or both depending on the supplier endpoint URL returned by the GET /suppliers.**
 
         This confirms an existing reservation. The `utcHoldExpiration` MUST NOT be elapsed when this request is sent, otherwise the response MAY show a `status` of `EXPIRED`.
+
+        This call has to be idempotent. To be able to safely retry a call on any network error or timeout, therefore it MUST not fail on retry. The idempotency key is the UUID.
       operationId: 'confirmReservation'
       parameters:
         - $ref: '#/components/parameters/SupplierId'


### PR DESCRIPTION
I think it's important to highlight in the spec a necessity of idempotent booking calls. 

Reservation, booking confirmation and cancellation requests have to be idempotent in a way, that when a client timeouts or fails, networking error occurs or a server fails to process a response for any reason, then a call with the same booking UUID can be retried without worrying about creating duplicate bookings or failing. 

This will essentially allow clients to be asynchronous, do retries, or to orchestrate a distributed transaction. 