### PR TITLE
Bugfix/remove duplicate fields

### DIFF
--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -1198,8 +1198,6 @@ components:
               - availabilityId
               - unitItems
             properties:
-              uuid:
-                $ref: '#/components/schemas/Uuid'
               resellerReference:
                 $ref: '#/components/schemas/ResellerReference'
               productId:

--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -1193,7 +1193,6 @@ components:
           schema:
             type: object
             required:
-              - uuid
               - productId
               - optionId
               - availabilityId


### PR DESCRIPTION
Avoid redundancy of UUID in reservation path param and request body to avoid possible inconsistency when implementing the spec.