### PR TITLE
Clean up booking creation and retrieval

### DIFF
--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -212,31 +212,6 @@ paths:
           $ref: '#/components/responses/InternalServerError'
 
   /suppliers/{supplierId}/bookings:
-    get:
-      tags:
-        - Bookings
-      summary: 'Gets the current details of an in-progress reservation or completed booking.'
-      description: |
-        **WARNING: this endpoint may live under a different domain, path or both depending on the supplier endpoint URL returned by the GET /suppliers.**
-
-        This returns the current state of any valid booking. This request MAY be made at any point after the initial `createReservation` request is processed successfully and it MUST return the booking reservation object.
-      operationId: 'getBooking'
-      parameters:
-        - $ref: '#/components/parameters/SupplierId'
-        - $ref: '#/components/parameters/Uuid'
-      responses:
-        '200':
-          $ref: '#/components/responses/BookingReservationResponse'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
     post:
       tags:
         - Bookings
@@ -270,10 +245,12 @@ paths:
     get:
       tags:
         - Bookings
-      summary: 'Get the booking details.'
+      summary: 'Gets the current details of an in-progress reservation or completed booking.'
       description: |
         **WARNING: this endpoint may live under a different domain, path or both depending on the supplier endpoint URL returned by the GET /suppliers.**
-      operationId: 'getBookings'
+
+        This returns the current state of any valid booking. This request MAY be made at any point after the initial `createReservation` request is processed successfully and it MUST return the booking reservation object.
+      operationId: 'getBooking'
       parameters:
         - $ref: '#/components/parameters/SupplierId'
         - $ref: '#/components/parameters/Uuid'

--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -237,31 +237,6 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-
-  /suppliers/{supplierId}/bookings/{uuid}:
-    get:
-      tags:
-        - Bookings
-      summary: 'Get the booking details.'
-      description: |
-        **WARNING: this endpoint may live under a different domain, path or both depending on the supplier endpoint URL returned by the GET /suppliers.**
-      operationId: 'getBookings'
-      parameters:
-        - $ref: '#/components/parameters/SupplierId'
-        - $ref: '#/components/parameters/Uuid'
-      responses:
-        '200':
-          $ref: '#/components/responses/BookingReservationResponse'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
     post:
       tags:
         - Bookings
@@ -275,9 +250,33 @@ paths:
       operationId: 'createReservation'
       parameters:
         - $ref: '#/components/parameters/SupplierId'
-        - $ref: '#/components/parameters/Uuid'
       requestBody:
         $ref: '#/components/requestBodies/CreateReservationRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/BookingReservationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /suppliers/{supplierId}/bookings/{uuid}:
+    get:
+      tags:
+        - Bookings
+      summary: 'Get the booking details.'
+      description: |
+        **WARNING: this endpoint may live under a different domain, path or both depending on the supplier endpoint URL returned by the GET /suppliers.**
+      operationId: 'getBookings'
+      parameters:
+        - $ref: '#/components/parameters/SupplierId'
+        - $ref: '#/components/parameters/Uuid'
       responses:
         '200':
           $ref: '#/components/responses/BookingReservationResponse'


### PR DESCRIPTION
I dunno how this oversight was made, but booking creation endpoint doesn't have the UUID in the URL path it's in the request body.