### PR TITLE
Spec cleanup

### DIFF
--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -632,6 +632,19 @@ components:
           description: |
             Represents the value for the voucher or ticket that should be used. If the `deliveryFormat` is `PDF_URL` then this value MUST be a valid [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) that resolves to a `PDF` resource. For any other `deliveryFormat` this value MUST be encoded according to the `deliveryFormat` value.
           example: '01234567890'
+    ExtendReason:
+      type: string
+      enum:
+        - FRAUD_CHECK
+        - CUSTOMER_REQUESTED
+        - OTHER
+      description: |
+        This indicates the reason for extending the booking hold.
+
+        * `FRAUD_CHECK` is the most common scenario where additional time is required to ensure that the booking is not being made using fraudulent payment information.
+        * `CUSTOMER_REQUESTED` is intended for scenarios where the customer is actively completing the checkout process but requires some additional time to complete. The Reseller SHOULD try to ensure that customers may only extend their booking once.
+        * `OTHER` can be used in other unusual circumstances but SHOULD not be abused to maintain a hold without good reason. If this value is specified the Reseller SHOULD provide `reasonDetails` to explain the justification.
+      example: 'FRAUD_CHECK'
     Locale:
       type: string
       description: |
@@ -1223,18 +1236,7 @@ components:
               - holdExpirationMinutes
             properties:
               reason:
-                type: string
-                enum:
-                  - FRAUD_CHECK
-                  - CUSTOMER_REQUESTED
-                  - OTHER
-                description: |
-                  This indicates the reason for extending the booking hold.
-
-                  * `FRAUD_CHECK` is the most common scenario where additional time is required to ensure that the booking is not being made using fraudulent payment information.
-                  * `CUSTOMER_REQUESTED` is intended for scenarios where the customer is actively completing the checkout process but requires some additional time to complete. The Reseller SHOULD try to ensure that customers may only extend their booking once.
-                  * `OTHER` can be used in other unusual circumstances but SHOULD not be abused to maintain a hold without good reason. If this value is specified the Reseller SHOULD provide `reasonDetails` to explain the justification.
-                example: 'FRAUD_CHECK'
+                $ref: '#/components/schemas/ExtendReason'
               reasonDetails:
                 type: string
                 nullable: true

--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -118,7 +118,7 @@ paths:
 
         If the product's `availabilityType` is `OPENING_HOURS` then the `localDateTimeStart` and `localDateTimeEnd` are the hours of operation. If a product has more than one hours of operation on the same day (e.g. the supplier is open 8-5 but closed for lunch from 12-1) then one availability object MUST be returned for each contiguous range of time for that day.
 
-        The availability `id` value MUST be sent when making a Reservation request.
+        The availability `id` value MUST be sent when making a Booking request.
 
         The `status` field SHOULD be used to infer how frequently your cache should be updated from the Booking Platform. The RECOMMENDED frequency is as follows:
 
@@ -172,7 +172,7 @@ paths:
       description: |
         **WARNING: this endpoint may live under a different domain, path or both depending on the supplier endpoint URL returned by the GET /suppliers.**
 
-        This request is intended to provide the Booking Platform a complete view of the Unit IDs, Unit quantity, and Availability IDs so that additional restrictions and policies can be validated within the Booking Platform prior to making a Reservation. The purpose is to provide a clear and accurate answer to the Reseller about whether the requested booking configuration could be accepted by the Supplier. This is to support complex booking requirements without the Reseller needing to know the details of the restriction (e.g. "must purchase at least 1 adult ticket if a child ticket is purchased").
+        This request is intended to provide the Booking Platform a complete view of the Unit IDs, Unit quantity, and Availability IDs so that additional restrictions and policies can be validated within the Booking Platform prior to making a Booking. The purpose is to provide a clear and accurate answer to the Reseller about whether the requested booking configuration could be accepted by the Supplier. This is to support complex booking requirements without the Reseller needing to know the details of the restriction (e.g. "must purchase at least 1 adult ticket if a child ticket is purchased").
       operationId: 'availabilityCheck'
       parameters:
         - $ref: '#/components/parameters/SupplierId'
@@ -214,21 +214,21 @@ paths:
     post:
       tags:
         - Bookings
-      summary: 'Create a new booking reservation.'
+      summary: 'Create a new pending booking.'
       description: |
         **WARNING: this endpoint may live under a different domain, path or both depending on the supplier endpoint URL returned by the GET /suppliers.**
 
-        This creates a new booking reservation.
+        This creates a new pending booking.
 
-        This call has to be idempotent. To be able to safely retry a call on any network error or timeout, therefore it MUST not fail on retry or create a duplicate reservation. The idempotency key is the UUID. A supplier SHOULD verify that a retried request with the same UUID is matching the original reservation data, to avoid erroneous clients generating repeating UUIDs and response with the status 400 and ErrorCode 1005 in such case.
-      operationId: 'createReservation'
+        This call has to be idempotent. To be able to safely retry a call on any network error or timeout, therefore it MUST not fail on retry or create a duplicate booking. The idempotency key is the UUID. A supplier SHOULD verify that a retried request with the same UUID is matching the original booking data, to avoid erroneous clients generating repeating UUIDs and response with the status 400 and ErrorCode 1005 in such case.
+      operationId: 'createBooking'
       parameters:
         - $ref: '#/components/parameters/SupplierId'
       requestBody:
-        $ref: '#/components/requestBodies/CreateReservationRequest'
+        $ref: '#/components/requestBodies/CreateBookingRequest'
       responses:
         '200':
-          $ref: '#/components/responses/BookingReservationResponse'
+          $ref: '#/components/responses/BookingResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -244,18 +244,18 @@ paths:
     get:
       tags:
         - Bookings
-      summary: 'Gets the current details of an in-progress reservation or completed booking.'
+      summary: 'Gets the current details of an in-progress booking or completed booking.'
       description: |
         **WARNING: this endpoint may live under a different domain, path or both depending on the supplier endpoint URL returned by the GET /suppliers.**
 
-        This returns the current state of any valid booking. This request MAY be made at any point after the initial `createReservation` request is processed successfully and it MUST return the booking reservation object.
+        This returns the current state of any valid booking. This request MAY be made at any point after the initial `createBooking` request is processed successfully and it MUST return the booking object.
       operationId: 'getBooking'
       parameters:
         - $ref: '#/components/parameters/SupplierId'
         - $ref: '#/components/parameters/Uuid'
       responses:
         '200':
-          $ref: '#/components/responses/BookingReservationResponse'
+          $ref: '#/components/responses/BookingResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -271,20 +271,20 @@ paths:
     post:
       tags:
         - Bookings
-      summary: 'Extend the hold of an existing reservation.'
+      summary: 'Extend the hold of an in-progress booking.'
       description: |
         **WARNING: this endpoint may live under a different domain, path or both depending on the supplier endpoint URL returned by the GET /suppliers.**
 
-        This extends the hold of an existing reservation. The `utcHoldExpiration` MUST NOT be elapsed when this request is sent, otherwise the response MAY show a `status` of `EXPIRED`.
-      operationId: 'extendReservation'
+        This extends the hold of an in-progress booking. The `utcHoldExpiration` MUST NOT be elapsed when this request is sent, otherwise the response MAY show a `status` of `EXPIRED`.
+      operationId: 'extendBooking'
       parameters:
         - $ref: '#/components/parameters/SupplierId'
         - $ref: '#/components/parameters/Uuid'
       requestBody:
-        $ref: '#/components/requestBodies/ExtendReservationRequest'
+        $ref: '#/components/requestBodies/ExtendBookingRequest'
       responses:
         '200':
-          $ref: '#/components/responses/BookingReservationResponse'
+          $ref: '#/components/responses/BookingResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -300,22 +300,22 @@ paths:
     post:
       tags:
         - Bookings
-      summary: 'Confirm an existing reservation'
+      summary: 'Confirm an in-progress booking.'
       description: |
         **WARNING: this endpoint may live under a different domain, path or both depending on the supplier endpoint URL returned by the GET /suppliers.**
 
-        This confirms an existing reservation. The `utcHoldExpiration` MUST NOT be elapsed when this request is sent, otherwise the response MAY show a `status` of `EXPIRED`.
+        This confirms an in-progress booking. The `utcHoldExpiration` MUST NOT be elapsed when this request is sent, otherwise the response MAY show a `status` of `EXPIRED`.
 
-        This call has to be idempotent. To be able to safely retry a call on any network error or timeout, therefore it MUST not fail on retry. The idempotency key is the UUID.
-      operationId: 'confirmReservation'
+        This call MUST be idempotent so that a Reseller may retry the request for any network error or timeout. The Booking `uuid` MUST be used to ensure idempotency of the request.
+      operationId: 'confirmBooking'
       parameters:
         - $ref: '#/components/parameters/SupplierId'
         - $ref: '#/components/parameters/Uuid'
       requestBody:
-        $ref: '#/components/requestBodies/ConfirmReservationRequest'
+        $ref: '#/components/requestBodies/ConfirmBookingRequest'
       responses:
         '200':
-          $ref: '#/components/responses/BookingReservationResponse'
+          $ref: '#/components/responses/BookingResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -327,24 +327,24 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  '/suppliers/{supplierId}/bookings/{uuid}/cancel':
+  /suppliers/{supplierId}/bookings/{uuid}/cancel:
     post:
       tags:
         - Bookings
-      summary: 'Either cancel the booking, or expire the hold of an existing reservation.'
+      summary: 'Either cancel the booking, or expire the hold of an in-progress booking.'
       description: |
         **WARNING: this endpoint may live under a different domain, path or both depending on the supplier endpoint URL returned by the GET /suppliers.**
 
-        This expires the availability hold of an existing reservation so that the availablity is release for other booking reservations. This request is a courtesy, however Resellers SHOULD send this in order to ensure proper cleanup of any outstanding holds.
+        This expires the availability hold of an in-progress booking so that the availablity is release for other bookings. This request is a courtesy, however Resellers SHOULD send this in order to ensure proper cleanup of any outstanding holds.
 
         This call has to be idempotent. To be able to safely retry a call on any network error or timeout, therefore it MUST not fail on retry. The idempotency key is the UUID.
-      operationId: expireReservation
+      operationId: 'cancelBooking'
       parameters:
         - $ref: '#/components/parameters/SupplierId'
         - $ref: '#/components/parameters/Uuid'
       responses:
         '200':
-          $ref: '#/components/responses/BookingReservationResponse'
+          $ref: '#/components/responses/BookingResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -464,7 +464,7 @@ components:
           format: date-time
           nullable: true
           description: |
-            This MUST be an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) compliant date and time. The value represents the time at which the reservation was confirmed (either automatically by the Booking Platform or manually by the Supplier).
+            This MUST be an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) compliant date and time. The value represents the time at which the booking was confirmed (either automatically by the Booking Platform or manually by the Supplier).
           example: '2019-10-31T08:30:00Z'
         utcDeliveredAt:
           type: string
@@ -698,7 +698,7 @@ components:
           description: |
             This indicates whether the Reseller can expect an immediate confirmation of whether the Supplier has accepted the booking. If `false` then the Reseller MUST be able to delay confirmation to the customer while waiting for the Supplier to accept or reject the Booking.
 
-            When `instantConfirmation` is set to `false` one should expect created reservations to first get into a `PENDING` state.
+            When `instantConfirmation` is set to `false` one should expect created bookings to first get into a `PENDING` state.
           example: true
         instantDelivery:
           type: boolean
@@ -812,36 +812,36 @@ components:
         An OPTIONAL tracking reference for the Reseller that SHOULD be tracked by the Booking Platform. This MUST be returned if the value was provided in the request body.
       example: '001-002'
     Status:
-          type: string
-          enum:
-            - ON_HOLD
-            - EXPIRED
-            - PENDING
-            - REJECTED
-            - CONFIRMED
-            - CANCELLED
-          description: |
-            After a successful `createReservation` request, the `status` MUST be `ON_HOLD`.
+      type: string
+      enum:
+        - ON_HOLD
+        - EXPIRED
+        - PENDING
+        - REJECTED
+        - CONFIRMED
+        - CANCELLED
+      description: |
+        After a successful `createBooking` request, the `status` MUST be `ON_HOLD`.
 
-            After a successful `confirmReservation` request, the `status` MUST be `CONFIRMED`.
+        After a successful `confirmBooking` request, the `status` MUST be `CONFIRMED`.
 
-            After a successful `confirmCancellation` request, the `status` MUST be `CANCELLED`.
+        After a successful `confirmCancellation` request, the `status` MUST be `CANCELLED`.
 
-            Following are the only valid Reservation flow status transitions:
+        Following are the only valid Booking flow status transitions:
 
-            * New Reservation -> `REJECTED`
-            * New Reservation -> `ON_HOLD` -> `EXPIRED`
-            * New Reservation -> `ON_HOLD` -> `CONFIRMED`
-            * New Reservation -> `ON_HOLD` -> `PENDING` -> `REJECTED`
-            * New Reservation -> `ON_HOLD` -> `PENDING` -> `CONFIRMED`
+        * New Booking -> `REJECTED`
+        * New Booking -> `ON_HOLD` -> `EXPIRED`
+        * New Booking -> `ON_HOLD` -> `CONFIRMED`
+        * New Booking -> `ON_HOLD` -> `PENDING` -> `REJECTED`
+        * New Booking -> `ON_HOLD` -> `PENDING` -> `CONFIRMED`
 
-            The `PENDING` status MAY appear only for products with the `instantConfirmation` property set to `false`. Poll the /bookings endpoint for status changes.
+        The `PENDING` status MAY appear only for products with the `instantConfirmation` property set to `false`. Poll the /bookings endpoint for status changes.
 
-            Following are the only valid Cancellation flow status transitions:
+        Following are the only valid Cancellation flow status transitions:
 
-            * `CONFIRMED` -> `CANCELLED`
-            * `ON_HOLD` -> `EXPIRED`
-          example: 'ON_HOLD'
+        * `CONFIRMED` -> `CANCELLED`
+        * `ON_HOLD` -> `EXPIRED`
+      example: 'ON_HOLD'
     Supplier:
       type: object
       required:
@@ -1020,7 +1020,7 @@ components:
       type: string
       format: uuid
       description: |
-        This UUID is generated for the initial `createReservation` request and MUST never change. This value MUST be tracked by both the Reseller and Booking Platform for locating this record.
+        This UUID is generated for the initial `createBooking` request and MUST never change. This value MUST be tracked by both the Reseller and Booking Platform for locating this record.
       example: '7df49d62-57ad-44be-8373-e4c2fe7e63fe'
     CalendarItem:
       title: CalendarItem
@@ -1048,9 +1048,9 @@ components:
     InternalServerError:
       description: |
         An unknown error occurred and the server cannot respond in a sensible way. The response may not include a valid error object if one could not be generated.
-    BookingReservationResponse:
+    BookingResponse:
       description: |
-        A complete representation of the current booking reservation status.
+        A complete representation of the current booking booking status.
       content:
         application/json:
           schema:
@@ -1105,7 +1105,7 @@ components:
       name: 'uuid'
       in: path
       description: |
-        A valid booking reservation UUID that matches the `uuid` sent during the initial `POST /suppliers/{supplierId}/bookings/{uuid}`
+        A valid booking UUID that matches the `uuid` sent during the initial `POST /suppliers/{supplierId}/bookings`
       required: true
       schema:
         type: string
@@ -1164,7 +1164,7 @@ components:
                   - id: 'child'
                     quantity: 1
                 minItems: 1
-    CreateReservationRequest:
+    CreateBookingRequest:
       required: true
       description: |
         This MUST include all unitItems that the customer wants to book.
@@ -1208,7 +1208,7 @@ components:
                 description: |
                   This is the duration that the Reseller would like the product inventory to be temporarily held while the booking is completed. The Booking Platform SHOULD reserve the inventory for at least this duration but MAY reserve for a shorter period of time. The exact hold expiration time will be returned in the response.
                 example: 30
-    ExtendReservationRequest:
+    ExtendBookingRequest:
       required: true
       description: |
         This MUST include the proper `reason` for requesting the extension and MUST NOT be abused to keep availability reserved due to processing delays by the Reseller.
@@ -1228,10 +1228,10 @@ components:
                   - CUSTOMER_REQUESTED
                   - OTHER
                 description: |
-                  This indicates the reason for extending the reservation hold.
+                  This indicates the reason for extending the booking hold.
 
-                  * `FRAUD_CHECK` is the most common scenario where additional time is required to ensure that the booking reservation is not being made using fraudulent payment information.
-                  * `CUSTOMER_REQUESTED` is intended for scenarios where the customer is actively completing the checkout process but requires some additional time to complete. The Reseller SHOULD try to ensure that customers may only extend their reservation once.
+                  * `FRAUD_CHECK` is the most common scenario where additional time is required to ensure that the booking is not being made using fraudulent payment information.
+                  * `CUSTOMER_REQUESTED` is intended for scenarios where the customer is actively completing the checkout process but requires some additional time to complete. The Reseller SHOULD try to ensure that customers may only extend their booking once.
                   * `OTHER` can be used in other unusual circumstances but SHOULD not be abused to maintain a hold without good reason. If this value is specified the Reseller SHOULD provide `reasonDetails` to explain the justification.
                 example: 'FRAUD_CHECK'
               reasonDetails:
@@ -1245,10 +1245,10 @@ components:
                 description: |
                   This is the duration that the Reseller would like the product inventory hold to be extended while the booking is completed. The Booking Platform SHOULD extend the hold on the inventory for at least this duration from the time of the request but MAY reserve for a shorter period of time. The exact hold expiration time will be returned in the response.
                 example: 120
-    ConfirmReservationRequest:
+    ConfirmBookingRequest:
       required: true
       description: |
-        This confirms an existing booking reservation and MUST be sent before the `utcHoldExpiration` has elapsed.
+        This confirms an in-progress booking and MUST be sent before the `utcHoldExpiration` has elapsed.
       content:
         application/json:
           schema:

--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -389,6 +389,23 @@ components:
         capacity:
           type: integer
           minimum: 0
+    AvailabilityDateStatus:
+      type: string
+      description: |
+        This represents whether the availability in this configuration is currently bookable. The values have the following meanings:
+
+        * `FREESALE`: Always available.
+        * `AVAILABLE`: Currently available for sale, but has a fixed capacity.
+        * `LIMITED`: Currently available for sale, but has a fixed capacity and may be sold out soon.
+        * `SOLD_OUT`: Currently sold out, but additional availability may free up.
+        * `CLOSED`: Currently not available for sale, but not sold out (e.g. temporarily on stop-sell) and may be available for sale soon.
+      enum:
+        - FREESALE
+        - AVAILABLE
+        - LIMITED
+        - SOLD_OUT
+        - CLOSED
+      example: 'AVAILABLE'
     AvailabilityId:
       type: string
       description: |
@@ -403,22 +420,7 @@ components:
             - vacancies
           properties:
             status:
-              type: string
-              description: |
-                This represents whether the availability in this configuration is currently bookable. The values have the following meanings:
-
-                * `FREESALE`: Always available.
-                * `AVAILABLE`: Currently available for sale, but has a fixed capacity.
-                * `LIMITED`: Currently available for sale, but has a fixed capacity and may be sold out soon.
-                * `SOLD_OUT`: Currently sold out, but additional availability may free up.
-                * `CLOSED`: Currently not available for sale, but not sold out (e.g. temporarily on stop-sell) and may be available for sale soon.
-              enum:
-                - FREESALE
-                - AVAILABLE
-                - LIMITED
-                - SOLD_OUT
-                - CLOSED
-              example: 'AVAILABLE'
+              $ref: '#/components/schemas/AvailabilityDateStatus'
             vacancies:
               type: integer
               nullable: true

--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -627,42 +627,6 @@ components:
       description: |
         This MUST be a valid [BCP 47](https://tools.ietf.org/html/bcp47) [RFC 5646](https://tools.ietf.org/html/rfc5646) [RFC 4647](https://tools.ietf.org/html/rfc4647) language tag.
       example: 'en-GB'
-    Option:
-      type: object
-      required:
-        - id
-        - internalName
-        - units
-      properties:
-        id:
-          type: string
-          description: |
-            This MUST be a unique identifier within the scope of the Product.
-          example: '0001'
-        internalName:
-          type: string
-          description: |
-            This SHOULD be a friendly name for the Option to facilitate easier identification. It MUST NOT be shown to the customer.
-          example: 'Morning'
-        reference:
-          type: string
-          description: |
-            This is an internal reference identifier that the Supplier wishes to use. It MAY be non-unique.
-          example: 'LR1-01'
-        units:
-          type: array
-          items:
-            $ref: '#/components/schemas/Unit'
-          minItems: 1
-          example:
-            - id: 'adult'
-              internalName: 'Adult'
-              reference: 'LR1-01-01'
-              type: 'ADULT'
-            - id: '0001-0001-child'
-              internalName: 'Child'
-              reference: 'LR1-01-02'
-              type: 'CHILD'
     Product:
       type: object
       required:
@@ -755,7 +719,7 @@ components:
         options:
           type: array
           items:
-            $ref: '#/components/schemas/Option'
+            $ref: '#/components/schemas/ProductOption'
           minItems: 1
           example:
             - id: '0001'
@@ -782,6 +746,42 @@ components:
                   internalName: 'Child'
                   reference: 'LR1-01-02'
                   type: 'CHILD'
+    ProductOption:
+      type: object
+      required:
+        - id
+        - internalName
+        - units
+      properties:
+        id:
+          type: string
+          description: |
+            This MUST be a unique identifier within the scope of the Product.
+          example: '0001'
+        internalName:
+          type: string
+          description: |
+            This SHOULD be a friendly name for the Option to facilitate easier identification. It MUST NOT be shown to the customer.
+          example: 'Morning'
+        reference:
+          type: string
+          description: |
+            This is an internal reference identifier that the Supplier wishes to use. It MAY be non-unique.
+          example: 'LR1-01'
+        units:
+          type: array
+          items:
+            $ref: '#/components/schemas/Unit'
+          minItems: 1
+          example:
+            - id: 'adult'
+              internalName: 'Adult'
+              reference: 'LR1-01-01'
+              type: 'ADULT'
+            - id: '0001-0001-child'
+              internalName: 'Child'
+              reference: 'LR1-01-02'
+              type: 'CHILD'
     Reason:
       type: string
       enum:

--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -406,11 +406,6 @@ components:
         - SOLD_OUT
         - CLOSED
       example: 'AVAILABLE'
-    AvailabilityId:
-      type: string
-      description: |
-        A valid availability ID that matches the `id` returned from `GET /availability`.
-      example: '28271273-a317-40fc-8f42-79725a7072a3'
     AvailabilityStatus:
       allOf:
         - $ref: '#/components/schemas/Availability'
@@ -459,9 +454,17 @@ components:
             This is a randomly-generated UUID that MUST be tracked by both the Reseller and Booking Platform for locating this record.
           example: 'f149068e-300e-452a-a856-3f091239f1d7'
         resellerReference:
-          $ref: '#/components/schemas/ResellerReference'
+          type: string
+          nullable: true
+          description: |
+            An OPTIONAL tracking reference for the Reseller that SHOULD be tracked by the Booking Platform. This MUST be returned if the value was provided in the request body.
+          example: '001-002'
         supplierReference:
-          $ref: '#/components/schemas/SupplierReference'
+          type: string
+          nullable: true
+          description: |
+            An OPTIONAL tracking reference for the Supplier that SHOULD be tracked by the Reseller.
+          example: 'ABC-123'
         status:
           $ref: '#/components/schemas/Status'
         cancellable:
@@ -573,7 +576,10 @@ components:
         locales:
           type: array
           items:
-            $ref: '#/components/schemas/Locale'
+            type: string
+            description: |
+              This MUST be a valid [BCP 47](https://tools.ietf.org/html/bcp47) [RFC 5646](https://tools.ietf.org/html/rfc5646) [RFC 4647](https://tools.ietf.org/html/rfc4647) language tag.
+            example: 'en-GB'
           example:
             - en-GB
             - en-US
@@ -634,11 +640,6 @@ components:
         * `CUSTOMER_REQUESTED` is intended for scenarios where the customer is actively completing the checkout process but requires some additional time to complete. The Reseller SHOULD try to ensure that customers may only extend their booking once.
         * `OTHER` can be used in other unusual circumstances but SHOULD not be abused to maintain a hold without good reason. If this value is specified the Reseller SHOULD provide `reasonDetails` to explain the justification.
       example: 'FRAUD_CHECK'
-    Locale:
-      type: string
-      description: |
-        This MUST be a valid [BCP 47](https://tools.ietf.org/html/bcp47) [RFC 5646](https://tools.ietf.org/html/rfc5646) [RFC 4647](https://tools.ietf.org/html/rfc4647) language tag.
-      example: 'en-GB'
     Product:
       type: object
       required:
@@ -670,7 +671,10 @@ components:
             This is an internal reference identifier that the Supplier wishes to use. It MAY be non-unique.
           example: 'LR1-01'
         locale:
-          $ref: '#/components/schemas/Locale'
+          type: string
+          description: |
+            This MUST be a valid [BCP 47](https://tools.ietf.org/html/bcp47) [RFC 5646](https://tools.ietf.org/html/rfc5646) [RFC 4647](https://tools.ietf.org/html/rfc4647) language tag.
+          example: 'en-GB'
         timeZone:
           type: string
           description: |
@@ -831,12 +835,6 @@ components:
         * To see if a booking has changed from `CONFIRMED` to `CANCELLED` in the event of a supplier-initiated cancellation.
         * To see if a booking has an updated `utcRedeemedAt`/`utcResolvedAt` value for the Voucher or any of the Tickets.
       example: 'HOURLY'
-    ResellerReference:
-      type: string
-      nullable: true
-      description: |
-        An OPTIONAL tracking reference for the Reseller that SHOULD be tracked by the Booking Platform. This MUST be returned if the value was provided in the request body.
-      example: '001-002'
     Status:
       type: string
       enum:
@@ -923,12 +921,6 @@ components:
           description: |
             This SHOULD be the mail address support contact for the Supplier. This information MAY be provided to the customer.
           example: '123 Main St, Anytown USA'
-    SupplierReference:
-      type: string
-      nullable: true
-      description: |
-        An OPTIONAL tracking reference for the Supplier that SHOULD be tracked by the Reseller.
-      example: 'ABC-123'
     Ticket:
       type: object
       required:
@@ -998,7 +990,11 @@ components:
             A valid unit ID that matches the `id` returned from `GET /suppliers/{supplierId}/products`.
           example: 'adult'
         resellerReference:
-          $ref: '#/components/schemas/ResellerReference'
+          type: string
+          nullable: true
+          description: |
+            An OPTIONAL tracking reference for the Reseller that SHOULD be tracked by the Booking Platform. This MUST be returned if the value was provided in the request body.
+          example: '001-002'
     UnitItemTicket:
       allOf:
         - $ref: '#/components/schemas/UnitItem'
@@ -1007,7 +1003,11 @@ components:
             - ticket
           properties:
             supplierReference:
-              $ref: '#/components/schemas/SupplierReference'
+              type: string
+              nullable: true
+              description: |
+                An OPTIONAL tracking reference for the Supplier that SHOULD be tracked by the Reseller.
+              example: 'ABC-123'
             ticket:
               # https://github.com/OAI/OpenAPI-Specification/issues/1368
               nullable: true
@@ -1044,12 +1044,6 @@ components:
         - RESOURCE
         - OTHER
       example: 'YOUTH'
-    Uuid:
-      type: string
-      format: uuid
-      description: |
-        This UUID is generated for the initial `createBooking` request and MUST never change. This value MUST be tracked by both the Reseller and Booking Platform for locating this record.
-      example: '7df49d62-57ad-44be-8373-e4c2fe7e63fe'
   responses:
     BadRequest:
       description: |
@@ -1167,7 +1161,10 @@ components:
               availabilityIds:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AvailabilityId'
+                  type: string
+                  description: |
+                    A valid list of availability IDs that matches the `id` returned from `GET /availability`.
+                  example: '28271273-a317-40fc-8f42-79725a7072a3'
                 example:
                   - '28271273-a317-40fc-8f42-79725a7072a3'
                   - '6143d137-fdf6-4da1-a558-20aa93eb55f0'
@@ -1198,9 +1195,17 @@ components:
               - unitItems
             properties:
               uuid:
-                $ref: '#/components/schemas/Uuid'
+                type: string
+                format: uuid
+                description: |
+                  This UUID is generated for the initial `createBooking` request and MUST never change. This value MUST be tracked by both the Reseller and Booking Platform for locating this record.
+                example: '7df49d62-57ad-44be-8373-e4c2fe7e63fe'
               resellerReference:
-                $ref: '#/components/schemas/ResellerReference'
+                type: string
+                nullable: true
+                description: |
+                  An OPTIONAL tracking reference for the Reseller that SHOULD be tracked by the Booking Platform. This MUST be returned if the value was provided in the request body.
+                example: '001-002'
               productId:
                 type: string
                 description: |
@@ -1264,7 +1269,11 @@ components:
               - contact
             properties:
               resellerReference:
-                $ref: '#/components/schemas/ResellerReference'
+                type: string
+                nullable: true
+                description: |
+                  An OPTIONAL tracking reference for the Reseller that SHOULD be tracked by the Booking Platform. This MUST be returned if the value was provided in the request body.
+                example: '001-002'
               contact:
                 $ref: '#/components/schemas/Contact'
   securitySchemes:

--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -980,20 +980,7 @@ components:
             This is an internal reference identifier that the Supplier wishes to use. It MAY be non-unique.
           example: 'LR1-01-new'
         type:
-          type: string
-          description: |
-            This is the base unit type for this unit definition. A value of `TRAVELLER` MUST only be used in replacement of `ADULT`, `CHILD`, `INFANT`, `YOUTH`, `STUDENT`, or `SENIOR`.
-          enum:
-            - ADULT
-            - CHILD
-            - INFANT
-            - YOUTH
-            - STUDENT
-            - SENIOR
-            - TRAVELLER
-            - RESOURCE
-            - OTHER
-          example: 'YOUTH'
+          $ref: '#/components/schemas/UnitType'
     UnitItem:
       type: object
       required:
@@ -1042,6 +1029,21 @@ components:
           description: |
             The total number of this unit that the customer wants to purchase.
           example: 2
+    UnitType:
+      type: string
+      description: |
+        This is the base unit type for this unit definition. A value of `TRAVELLER` MUST only be used in replacement of `ADULT`, `CHILD`, `INFANT`, `YOUTH`, `STUDENT`, or `SENIOR`.
+      enum:
+        - ADULT
+        - CHILD
+        - INFANT
+        - YOUTH
+        - STUDENT
+        - SENIOR
+        - TRAVELLER
+        - RESOURCE
+        - OTHER
+      example: 'YOUTH'
     Uuid:
       type: string
       format: uuid

--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -20,7 +20,7 @@ paths:
       summary: 'Returns a list of suppliers and associated contact details.'
       description: |
         This list MAY be limited based on the suppliers that the authenticated user has been granted access to.
-      operationId: 'getSuppliers'
+      operationId: 'suppliers'
       responses:
         '200':
           description: |
@@ -51,7 +51,7 @@ paths:
         **WARNING: this endpoint may live under a different domain, path or both depending on the supplier endpoint URL returned by the GET /suppliers.**
 
         Contains all product details necessary to ingest, map, and sell.
-      operationId: 'getProducts'
+      operationId: 'products'
       parameters:
         - $ref: '#/components/parameters/SupplierId'
       responses:
@@ -199,7 +199,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/AvailabilityCalendarItem'
-      operationId: getCalendar
+      operationId: 'availabilityCalendar'
       parameters:
         - $ref: '#/components/parameters/LocalDateStart'
         - $ref: '#/components/parameters/LocalDateEnd'
@@ -246,7 +246,7 @@ paths:
         **WARNING: this endpoint may live under a different domain, path or both depending on the supplier endpoint URL returned by the GET /suppliers.**
 
         This returns the current state of any valid booking. This request MAY be made at any point after the initial `createBooking` request is processed successfully and it MUST return the booking object.
-      operationId: 'getBooking'
+      operationId: 'booking'
       parameters:
         - $ref: '#/components/parameters/SupplierId'
         - $ref: '#/components/parameters/Uuid'

--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -380,7 +380,6 @@ components:
           format: date-time
           example: '2019-10-31T10:00:00Z'
     AvailabilityCalendarItem:
-      title: CalendarItem
       type: object
       properties:
         localDate:

--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -427,6 +427,14 @@ components:
               description: |
                 Returns `null` when `status` is `FREESALE`. This SHOULD be a shared pool for all Unit types in the Option. If availability is tracked per-Unit then this value MUST be equal to the available quantity for the Unit that has the most remaining.
               example: 100
+    AvailabilityType:
+      type: string
+      description: |
+        This indicates whether the Product redemption is valid only for a specific start time (e.g. a guided tour) or valid any time during normal business hours.
+      enum:
+        - START_TIME
+        - OPENING_HOURS
+      example: 'START_TIME'
     Booking:
       type: object
       required:
@@ -679,13 +687,7 @@ components:
             This indicates whether the Reseller can expect immediate delivery of the customer's tickets. If `false` then the Reseller MUST be able to delay delivery of the tickets to the customer.
           example: true
         availabilityType:
-          type: string
-          description: |
-            This indicates whether the Product redemption is valid only for a specific start time (e.g. a guided tour) or valid any time during normal business hours.
-          enum:
-            - START_TIME
-            - OPENING_HOURS
-          example: 'START_TIME'
+          $ref: '#/components/schemas/AvailabilityType'
         deliveryFormats:
           type: array
           items:

--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -75,36 +75,6 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /suppliers/{supplierId}/availability/calendar:
-    get:
-      tags:
-        - Availability
-      summary: Get a list of dates on which tickets are available
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/CalendarItem'
-      operationId: getCalendar
-      parameters:
-        - $ref: '#/components/parameters/LocalDateStart'
-        - $ref: '#/components/parameters/LocalDateEnd'
-        - $ref: '#/components/parameters/ProductId'
-        - $ref: '#/components/parameters/SupplierId'
-        - $ref: '#/components/parameters/OptionIds'
-      description: |-
-        **WARNING: this endpoint may live under a different domain, path or both depending on the supplier endpoint URL returned by the GET /suppliers.**
-
-        Returns a list of dates on which tickets are available.
-        Only dates that have availability SHALL BE returned.
-        A minimum range of 31 days MUST BE supported.
-
-        This endpoint proved a relatively lightweight way to show a calendar in a user interface containing a one month calendar with the days where there is no availability greyed out.
-
   /suppliers/{supplierId}/availability:
     get:
       tags:
@@ -208,6 +178,34 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+
+  /suppliers/{supplierId}/availability/calendar:
+    get:
+      tags:
+        - Availability
+      summary: 'Get a list of dates on which tickets are available'
+      description: |
+        **WARNING: this endpoint may live under a different domain, path or both depending on the supplier endpoint URL returned by the GET /suppliers.**
+
+        Returns a list of dates (no times) and the number of vacancies. The response MUST only include dates that have vacancies and a minimum range of 31 days MUST be supported.
+
+        This endpoint is intended to support a lightweight way to show a calendar in a user interface containing a one month view with the days where there is no availability greyed out.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AvailabilityCalendarItem'
+      operationId: getCalendar
+      parameters:
+        - $ref: '#/components/parameters/LocalDateStart'
+        - $ref: '#/components/parameters/LocalDateEnd'
+        - $ref: '#/components/parameters/ProductId'
+        - $ref: '#/components/parameters/SupplierId'
+        - $ref: '#/components/parameters/OptionIds'
 
   /suppliers/{supplierId}/bookings:
     post:
@@ -381,6 +379,21 @@ components:
             This MUST be an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) compliant date and time.
           format: date-time
           example: '2019-10-31T10:00:00Z'
+    AvailabilityCalendarItem:
+      title: CalendarItem
+      type: object
+      properties:
+        localDate:
+          type: string
+          format: date
+        capacity:
+          type: integer
+          minimum: 0
+    AvailabilityId:
+      type: string
+      description: |
+        A valid availability ID that matches the `id` returned from `GET /availability`.
+      example: '28271273-a317-40fc-8f42-79725a7072a3'
     AvailabilityStatus:
       allOf:
         - $ref: '#/components/schemas/Availability'
@@ -412,11 +425,6 @@ components:
               description: |
                 Returns `null` when `status` is `FREESALE`. This SHOULD be a shared pool for all Unit types in the Option. If availability is tracked per-Unit then this value MUST be equal to the available quantity for the Unit that has the most remaining.
               example: 100
-    AvailabilityId:
-      type: string
-      description: |
-        A valid availability ID that matches the `id` returned from `GET /availability`.
-      example: '28271273-a317-40fc-8f42-79725a7072a3'
     Booking:
       type: object
       required:
@@ -1021,16 +1029,6 @@ components:
       description: |
         This UUID is generated for the initial `createBooking` request and MUST never change. This value MUST be tracked by both the Reseller and Booking Platform for locating this record.
       example: '7df49d62-57ad-44be-8373-e4c2fe7e63fe'
-    CalendarItem:
-      title: CalendarItem
-      type: object
-      properties:
-        localDate:
-          type: string
-          format: date
-        capacity:
-          type: integer
-          minimum: 0
   responses:
     BadRequest:
       description: |

--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -491,18 +491,7 @@ components:
             This MUST be an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) compliant date and time. The value represents the time at whcih the VOUCHER was delivered.
           example: '2019-10-31T08:30:00Z'
         refreshFrequency:
-          type: string
-          enum:
-            - HOURLY
-            - DAILY
-          description: |
-            This is the RECOMMENDED refresh interval for the Reseller and SHOULD be used by the Reseller to control the frequency at which they make a `getBooking` request for the following scenarios:
-
-            * To see if a booking has changed out of a `PENDING` status into `CONFIRMED` or `REJECTED`.
-            * To see if a booking has had any new Vouchers or Tickets delivered for the booking.
-            * To see if a booking has changed from `CONFIRMED` to `CANCELLED` in the event of a supplier-initiated cancellation.
-            * To see if a booking has an updated `utcRedeemedAt`/`utcResolvedAt` value for the Voucher or any of the Tickets.
-          example: 'HOURLY'
+          $ref: '#/components/schemas/RefreshFrequency'
         productId:
           type: string
           description: |
@@ -829,6 +818,19 @@ components:
         - DIGITAL
         - PRINT
       example: 'DIGITAL'
+    RefreshFrequency:
+      type: string
+      enum:
+        - HOURLY
+        - DAILY
+      description: |
+        This is the RECOMMENDED refresh interval for the Reseller and SHOULD be used by the Reseller to control the frequency at which they make a `getBooking` request for the following scenarios:
+
+        * To see if a booking has changed out of a `PENDING` status into `CONFIRMED` or `REJECTED`.
+        * To see if a booking has had any new Vouchers or Tickets delivered for the booking.
+        * To see if a booking has changed from `CONFIRMED` to `CANCELLED` in the event of a supplier-initiated cancellation.
+        * To see if a booking has an updated `utcRedeemedAt`/`utcResolvedAt` value for the Voucher or any of the Tickets.
+      example: 'HOURLY'
     ResellerReference:
       type: string
       nullable: true

--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -1,5 +1,4 @@
 openapi: 3.0.0
-# Added by API Auto Mocking Plugin
 info:
   description: |
     An open-source API for connecting Resellers and Booking Platforms.
@@ -1114,7 +1113,7 @@ components:
       name: optionIds
       in: query
       description: |
-        A list of valid option IDs that matches `id`s returned from `GET /suppliers/{supplierId}/products`. TODO: IS THIS REALLY CORRECT??
+        A list of valid option IDs that matches `id`s returned from `GET /suppliers/{supplierId}/products`.
       schema:
         type: array
         items:
@@ -1260,7 +1259,6 @@ components:
                 $ref: '#/components/schemas/ResellerReference'
               contact:
                 $ref: '#/components/schemas/Contact'
-
   securitySchemes:
     apiKey:
       type: apiKey


### PR DESCRIPTION
This is PR is for cleaning up the spec document, but represents no functional change to the API. The following cleanup items are included:

* Rename all `Reservation` references to `Booking`
* Removing extraneous comments not relevant to the API schema
* Moved Availability Calendar endpoint for better UI rendering
* Renamed `Option` object to `ProductOption` to avoid compatibility issues with auto-generated code since this is a reserved keyword in many languages
* Created new objects for several enum fields to improve auto-generated code and to make tracking changes easier in future spec updates
* Denormalized several objects that only represented primitive data types because this created useless/invalid classes when auto-generating code
* Normalized `operationId` values so that endpoints which only retrieve information from the server DO NOT contain a verb in the `operationId` and endpoints that create/modify information on the server DO contain a verb in the `operationId`.