### PR TITLE
Simplify Availability Calendar endpoint to require a single OptionId

### DIFF
--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -190,6 +190,13 @@ paths:
         Returns a list of dates (no times) and the number of vacancies. The response MUST only include dates that have vacancies and a minimum range of 31 days MUST be supported.
 
         This endpoint is intended to support a lightweight way to show a calendar in a user interface containing a one month view with the days where there is no availability greyed out.
+      operationId: 'availabilityCalendar'
+      parameters:
+        - $ref: '#/components/parameters/LocalDateStart'
+        - $ref: '#/components/parameters/LocalDateEnd'
+        - $ref: '#/components/parameters/ProductId'
+        - $ref: '#/components/parameters/SupplierId'
+        - $ref: '#/components/parameters/OptionId'
       responses:
         '200':
           description: OK
@@ -199,13 +206,16 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/AvailabilityCalendarItem'
-      operationId: 'availabilityCalendar'
-      parameters:
-        - $ref: '#/components/parameters/LocalDateStart'
-        - $ref: '#/components/parameters/LocalDateEnd'
-        - $ref: '#/components/parameters/ProductId'
-        - $ref: '#/components/parameters/SupplierId'
-        - $ref: '#/components/parameters/OptionIds'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /suppliers/{supplierId}/bookings:
     post:
@@ -1145,17 +1155,6 @@ components:
       schema:
         type: string
         format: uuid
-    OptionIds:
-      name: optionIds
-      in: query
-      description: |
-        A list of valid option IDs that matches `id`s returned from `GET /suppliers/{supplierId}/products`.
-      schema:
-        type: array
-        items:
-          type: string
-          format: string
-      required: false
   requestBodies:
     AvailabilityCheckRequest:
       required: true


### PR DESCRIPTION
This will simplify implementation and support caching by making it easier to cache a single OptionId request vs a variable list of OptionIds.