### PR TITLE
Small cleanup for Calendar endpoint

### DIFF
--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -112,7 +112,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AvailabilityStatus'
+                  $ref: '#/components/schemas/AvailabilityItem'
                 example:
                   - id: '28271273-a317-40fc-8f42-79725a7072a3'
                     localDateTimeStart: '2019-10-31T08:30:00Z'
@@ -156,7 +156,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AvailabilityStatus'
+                  $ref: '#/components/schemas/AvailabilityItem'
                 example:
                   - id: '28271273-a317-40fc-8f42-79725a7072a3'
                     localDateTimeStart: '2019-10-31T08:30:00Z'
@@ -408,7 +408,7 @@ components:
             This SHOULD NOT be returned when `status` is `FREESALE`. This SHOULD be a shared pool for all Unit types in the Option. If availability is tracked per-Unit then this value MUST be equal to the available quantity for the Unit that has the most remaining.
           example: 100
           minimum: 0
-    AvailabilityDateStatus:
+    AvailabilityStatus:
       type: string
       description: |
         This represents whether the availability in this configuration is currently bookable. The values have the following meanings:
@@ -425,7 +425,7 @@ components:
         - SOLD_OUT
         - CLOSED
       example: 'AVAILABLE'
-    AvailabilityStatus:
+    AvailabilityItem:
       allOf:
         - $ref: '#/components/schemas/Availability'
         - type: object
@@ -433,7 +433,7 @@ components:
             - status
           properties:
             status:
-              $ref: '#/components/schemas/AvailabilityDateStatus'
+              $ref: '#/components/schemas/AvailabilityStatus'
             vacancies:
               type: integer
               description: |

--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -393,12 +393,20 @@ components:
           example: '2019-10-31T10:00:00Z'
     AvailabilityCalendarItem:
       type: object
+      required:
+        - localDate
       properties:
         localDate:
           type: string
+          description: |
+            This MUST be an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) compliant date.
           format: date
-        capacity:
+          example: '2019-10-31'
+        vacancies:
           type: integer
+          description: |
+            This SHOULD NOT be returned when `status` is `FREESALE`. This SHOULD be a shared pool for all Unit types in the Option. If availability is tracked per-Unit then this value MUST be equal to the available quantity for the Unit that has the most remaining.
+          example: 100
           minimum: 0
     AvailabilityDateStatus:
       type: string
@@ -431,6 +439,7 @@ components:
               description: |
                 This SHOULD NOT be returned when `status` is `FREESALE`. This SHOULD be a shared pool for all Unit types in the Option. If availability is tracked per-Unit then this value MUST be equal to the available quantity for the Unit that has the most remaining.
               example: 100
+              minimum: 0
     AvailabilityType:
       type: string
       description: |


### PR DESCRIPTION
- Standardize model names for Availability endpoints
- Changed "capacity" to "vacancies" to be consistent with AvailabilityStatus model
- Added required fields
- Added descriptions for both fields
- Added example values
- Added minimum values