### PR TITLE
Standardize authentication mechanism

### DIFF
--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -1319,14 +1319,14 @@ components:
                 description: |
                   This field provides additional details about the reason for the cancellation request. It may include information from the customer, supplier, or support agent about the reason for the cancellation (especially in the case of requesting a cancellation outside of the normal policy which may require manual approval from the supplier).
                 example: 'Child came down with the flu the day before the activity.'
+
   securitySchemes:
-    apiKey:
-      type: apiKey
-      name: Authorization
-      in: header
+    bearerAuth:
+      type: http
+      scheme: bearer
 
 security:
-  - apiKey: []
+  - bearerAuth: []
 
 tags:
   - name: Suppliers

--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -1324,6 +1324,7 @@ components:
     bearerAuth:
       type: http
       scheme: bearer
+      bearerFormat: Bearer {apiKey}
 
 security:
   - bearerAuth: []


### PR DESCRIPTION
On the last technical call (20 Feb), the group realized that there was a lot of inconsistencies in the way authorization was implemented and it was agreed to adopt the scheme that was most widely implemented within the group. The 3 options were:

1. Basic auth with user and pass
2. API key auth using `Authorization` header
3. API key auth using `Authorization` header with `Bearer` token

Option 3 was what was most common, so the consensus was to use that as the scheme moving forward.