### PR TITLE
Capability/pricing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@
 
 # Ignore npm packages
 node_modules
+
+### IntelliJ IDEA metadata files ###
+.idea
+*.iws
+*.iml
+*.ipr

--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -39,10 +39,10 @@ paths:
                   $ref: '#/components/schemas/ErrorObject'
                 minItems: 1
               example:
-                  errorClass: 'unknownError'
-                  errorCode: 'core/9000'
-                  errorMessage: 'the stars are not aligned'
-                  retryable: true
+                errorClass: 'unknownError'
+                errorCode: 'core/9000'
+                errorMessage: 'the stars are not aligned'
+                retryable: true
           description: |
             An error has occurred. See the definition of the ErrorObject for more details.
         '401':
@@ -169,7 +169,7 @@ paths:
                 - errorClass: 'illegalOperationError'
                   errorCode: 'core/9003'
                   errorMessage: '<localDateStart> date in the past'
-                  retryable: false                  
+                  retryable: false
           description: |
             An error has occurred. See the definition of the ErrorObject for more details.
         '401':
@@ -293,7 +293,7 @@ paths:
                 - errorClass: 'illegalOperationError'
                   errorCode: 'core/9003'
                   errorMessage: '<localDateStart> date in the past'
-                  retryable: false                  
+                  retryable: false
           description: |
             An error has occurred. See the definition of the ErrorObject for more details.
         '401':
@@ -530,20 +530,20 @@ components:
         - errorClass
         - errorCode
         - errorMessage
-        - retryable      
+        - retryable
       properties:
         errorClass:
           type: string
           enum:
-          - inputValidationError
-          - illegalOperationError
-          - unknownError
+            - inputValidationError
+            - illegalOperationError
+            - unknownError
           description: |
-            A high level classification of the error category.  
-            `illegalOperationError`: The client is trying to perform an operation that does not comply with certain business logic. Eg.: Trying to cancel a booking while the cancellation window has passed.  
-            
-            `inputValidationError`: One or more input parameters contain invalid values or are missing.  
-            
+            A high level classification of the error category.
+            `illegalOperationError`: The client is trying to perform an operation that does not comply with certain business logic. Eg.: Trying to cancel a booking while the cancellation window has passed.
+
+            `inputValidationError`: One or more input parameters contain invalid values or are missing.
+
             `unknownError`: A last-resort fallback option in case none of the other error classes seem appropriate. Usage of this error class is discouraged.
         errorMessage:
           type: string
@@ -560,40 +560,40 @@ components:
           type: string
           nullable: false
           description: |
-            Contains a namespaced error code.  
+            Contains a namespaced error code.
             The namespace is used to distinguish between core errors and the errors of custom capabilities the server may have implemented and
-              MUST match the regular expression /[a-z\-]*\/[0-9]{4}\/[a-zA-Z \-]*/.  
-              
-            The `9000-9999` range is reserved for official OCTo error codes.  
-            The `0000-8999` range can be used for scenarios that aren't covered by the OCTo spec.  
-            When no specific error code applies, use 9000.  
-            In serious cases use 9999 accompanied by an HTTP 500 status code. 
-              
+              MUST match the regular expression /[a-z\-]*\/[0-9]{4}\/[a-zA-Z \-]*/.
+
+            The `9000-9999` range is reserved for official OCTo error codes.
+            The `0000-8999` range can be used for scenarios that aren't covered by the OCTo spec.
+            When no specific error code applies, use 9000.
+            In serious cases use 9999 accompanied by an HTTP 500 status code.
+
             ## Prescribed error codes
-            Using error codes allows the client to programmatically handle errors or determine the gravity of the errors.  
-            The following is a selection of errors codes that should be implemented explicitly.  
-            Failure to do so makes is much harder for a client to re-use the same code with a different partner, without having to adjust to the new partner's errors.  
-            
-            `9000`: Generic error  
-            `9001`: Invalid or missing input  
-            `9002`: Unknown value provided  
-            `9003`: Date in the past  
-            `9004`: Insufficient availability  
-            `9005`: Cancellation not allowed  
-            `9006`: Date range too large  
-            `9007`: Reservation expired  
-            `9008`: Hold period too long  
-            `9009`: Cannot extend hold period  
-            `9010`: Reservation ID not found  
-            `9011`: Reservation expired  
-            `9999`: Generic error for all unexpected / unknown cases  
-              
+            Using error codes allows the client to programmatically handle errors or determine the gravity of the errors.
+            The following is a selection of errors codes that should be implemented explicitly.
+            Failure to do so makes is much harder for a client to re-use the same code with a different partner, without having to adjust to the new partner's errors.
+
+            `9000`: Generic error
+            `9001`: Invalid or missing input
+            `9002`: Unknown value provided
+            `9003`: Date in the past
+            `9004`: Insufficient availability
+            `9005`: Cancellation not allowed
+            `9006`: Date range too large
+            `9007`: Reservation expired
+            `9008`: Hold period too long
+            `9009`: Cannot extend hold period
+            `9010`: Reservation ID not found
+            `9011`: Reservation expired
+            `9999`: Generic error for all unexpected / unknown cases
+
           example: 'core/9000'
         retryable:
           type: boolean
           nullable: false
           description: |
-            The OCTO spec distinguishes between retryable and non-retryable errors. Typically any error is non-retryable, but there are a few exceptions. 
+            The OCTO spec distinguishes between retryable and non-retryable errors. Typically any error is non-retryable, but there are a few exceptions.
               * A __non-retryable__ error is an error that indicates human intervention is needed. For example
                 * Invalid product / unit ID provided - This suggests there is a mapping problem due to a changed configuration
                 * Insufficient credits - The outstanding rolling deposit with the supplier has depleted and a top-up is needed to continue sales. Note that support for this is not included in the core API specification.
@@ -627,6 +627,10 @@ components:
             This MUST be an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) compliant date and time.
           format: date-time
           example: '2019-10-31T10:00:00'
+        pricing:
+          type: array
+          description:
+          $ref: '#/components/schemas/UnitPrice'
     AvailabilityCalendarItem:
       type: object
       required:
@@ -1238,12 +1242,18 @@ components:
         - id
         - internalName
         - type
+        - pricing
       properties:
         id:
           type: string
           description: |
             This MUST be a unique identifier within the scope of the Option.
           example: 'youth_10_17'
+        name:
+          type: string
+          description: |
+            This SHOULD be a user-friendly name for the Unit which can be shown to the customer.
+          example: 'Youth'
         internalName:
           type: string
           description: |
@@ -1256,6 +1266,33 @@ components:
           example: 'LR1-01-new'
         type:
           $ref: '#/components/schemas/UnitType'
+        pricing:
+          type: array
+          $ref: '#/components/schemas/UnitPrice'
+    UnitPrice:
+      type: object
+      description: |
+        A unit pricing. A default unit price MUST be configured on a product level. A unit price MAY be overriden on availability level if a dynamic pricing is supported. A set of unit prices on availability level MUST BE a subset of product level prices.
+      required:
+        - net
+        - retail
+        - currency
+      properties:
+        net:
+          type: number
+          description: |
+            This MUST be a unique identifier within the scope of the Option.
+          example: '80'
+        retail:
+          type: number
+          description: |
+            This SHOULD be a user-friendly name for the Unit which can be shown to the customer.
+          example: '100'
+        currency:
+          type: string
+          description: |
+            3-letter ISO 4217 currency code.
+          example: 'AUD'
     UnitItem:
       type: object
       required:
@@ -1519,7 +1556,7 @@ components:
                 description: |
                   This is the duration that the Reseller would like the product inventory hold to be extended while the booking is completed. The Booking Platform SHOULD extend the hold on the inventory for at least this duration from the time of the request but MAY reserve for a shorter period of time. The exact hold expiration time will be returned in the response.
                 example: 120
-    
+
     ConfirmBookingRequest:
       required: true
       description: |

--- a/docs/openapi_v1.0.0-alpha.yaml
+++ b/docs/openapi_v1.0.0-alpha.yaml
@@ -144,11 +144,28 @@ paths:
                     localDateTimeEnd: '2019-10-31T10:00:00'
                     status: 'AVAILABLE'
                     vacancies: 100
+                    units:
+                      - id: 'adult'
+                        pricing:
+                          net: 45
+                          retail: 60
+                          currency: AUD
+                      - id: 'child'
+                        pricing:
+                        net: 28
+                        retail: 30
+                        currency: AUD
                   - id: '6143d137-fdf6-4da1-a558-20aa93eb55f0'
                     localDateTimeStart: '2019-10-31T12:00:00'
                     localDateTimeEnd: '2019-10-31T13:00:00'
                     status: 'FREESALE'
                     vacancies: null
+                    units:
+                      - id: 'youth_10_17'
+                        pricing:
+                          net: 70
+                          retail: 90
+                          currency: AUD
         '400':
           content:
             application/json:
@@ -627,10 +644,6 @@ components:
             This MUST be an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) compliant date and time.
           format: date-time
           example: '2019-10-31T10:00:00'
-        pricing:
-          type: array
-          description:
-          $ref: '#/components/schemas/UnitPrice'
     AvailabilityCalendarItem:
       type: object
       required:
@@ -657,6 +670,7 @@ components:
         - type: object
           required:
             - status
+            - units
           properties:
             status:
               $ref: '#/components/schemas/AvailabilityStatus'
@@ -666,6 +680,14 @@ components:
                 This SHOULD NOT be returned when `status` is `FREESALE`. This SHOULD be a shared pool for all Unit types in the Option. If availability is tracked per-Unit then this value MUST be equal to the available quantity for the Unit that has the most remaining.
               example: 100
               minimum: 0
+            units:
+              type: array
+              description: |
+                All units and their prices attached to this availability slot. It is REQUIRED that all units MUST be present here at the availability level in order to make them bookable. A price override MAY be applied to a unit, in case of a dynamic pricing per availability is supported.
+
+                Take, for example, a product with an `adult` unit. To make the `adult` unit bookable, it MUST be present at the availability level either with a default price from a product option level or an overridden dynamic price. The goal is to make a client implementation easier and avoid making another call to fetch a default price from a product.
+              items:
+                $ref: '#/components/schemas/UnitAvailability'
     AvailabilityStatus:
       type: string
       description: |
@@ -1040,10 +1062,24 @@ components:
                   internalName: 'Adult'
                   reference: 'LR1-01-01'
                   type: 'ADULT'
+                  pricing:
+                    - net: 80
+                      retail: 100
+                      currency: AUD
+                    - net: 60
+                      retail: 75
+                      currency: USD
                 - id: '0001-0001-child'
                   internalName: 'Child'
                   reference: 'LR1-01-02'
                   type: 'CHILD'
+                  pricing:
+                    - net: 40
+                      retail: 50
+                      currency: AUD
+                    - net: 30
+                      retail: 38
+                      currency: USD
             - id: '0002'
               internalName: 'Afternoon'
               reference: 'LR1-02'
@@ -1052,10 +1088,24 @@ components:
                   internalName: 'Adult'
                   reference: 'LR1-01-01'
                   type: 'ADULT'
+                  pricing:
+                    - net: 80
+                      retail: 100
+                      currency: AUD
+                    - net: 60
+                      retail: 75
+                      currency: USD
                 - id: '0001-0001-child'
                   internalName: 'Child'
                   reference: 'LR1-01-02'
                   type: 'CHILD'
+                  pricing:
+                    - net: 40
+                      retail: 50
+                      currency: AUD
+                    - net: 30
+                      retail: 38
+                      currency: USD
     ProductOption:
       type: object
       required:
@@ -1268,11 +1318,30 @@ components:
           $ref: '#/components/schemas/UnitType'
         pricing:
           type: array
-          $ref: '#/components/schemas/UnitPrice'
+          description: |
+            A default pricing for a product option. This default price MUST be provided here on a product option level. A unit price MAY be overriden on availability level if a dynamic pricing is supported. All currencies supported by a product MUST be included here.
+          items:
+            $ref: '#/components/schemas/UnitPrice'
+    UnitAvailability:
+      type: object
+      required:
+        - id
+        - pricing
+      properties:
+        id:
+          type: string
+          description: |
+            This MUST be a unique identifier within the scope of an Availability and it MUST be one of the Ids defined on this product option.
+          example: 'youth_10_17'
+        pricing:
+          type: array
+          description: A unit pricing, a dynamic product price override for a particular unit and currency applied for this availability slot.
+          items:
+            $ref: '#/components/schemas/UnitPrice'
     UnitPrice:
       type: object
       description: |
-        A unit pricing. A default unit price MUST be configured on a product level. A unit price MAY be overriden on availability level if a dynamic pricing is supported. A set of unit prices on availability level MUST BE a subset of product level prices.
+        A unit pricing for a particular currency.
       required:
         - net
         - retail
@@ -1281,12 +1350,12 @@ components:
         net:
           type: number
           description: |
-            This MUST be a unique identifier within the scope of the Option.
+            A NET price of this unit.
           example: '80'
         retail:
           type: number
           description: |
-            This SHOULD be a user-friendly name for the Unit which can be shown to the customer.
+            A recommended retail price of this unit.
           example: '100'
         currency:
           type: string


### PR DESCRIPTION
Adds a requirement for a mandatory unit pricing on product option level and optionally a price overrides on availability item level.

It is the first step for price support, the PR does not include yet some advanced capabilities such as:
* support for group price such as 'Group of 5'
* Support for multiple vacancies units such as 'Family of 2 adults and 2 children'

//do not merge this PR, it's jsut to highlight the changes, it should probably stay as a separate branch permanently or a new fork repo for the pricing capability?